### PR TITLE
Add AppVeyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,10 @@
+version: 0.0.{build}
+stack: node 11.10
+skip_tags: true
+image: Ubuntu1804
+build_script:
+- sh: >-
+    yarn
+test_script:
+- sh: >-
+    yarn test


### PR DESCRIPTION
After this pointing AppVeyor to this repository will make it execute all the tests, and we can get a fancy pass/fail badge! Badge not included here, the AppVeyor account should to be created first. I used ubuntu platform for no special reason, Windows could also be used. There could even be a separate build for both if needed. We've already seen things are not perfectly platform-agnostic. Node version 11.10 is specified for now, because jest versions before 24.3.0 don't work with node 11.11+ (we are using jest 24.1).