### PR TITLE
Make AppVeyor detect errors during webpacking

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,8 @@ image: Ubuntu1804
 build_script:
   - sh: >-
       yarn
+
+      yarn build
 test_script:
   - sh: >-
       yarn test

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "scripts": {
+    "build": "webpack --config webpack.config.js",
     "start": "npx webpack-dev-server --hot",
     "test": "yarn test:jest && yarn lint",
     "test:jest": "npx jest",


### PR DESCRIPTION
Adds a 'build' command that executes webpack, and makes AppVeyor run that 'build' command. If webpack returns non-zero exit code, the AV build fails. The purpose is to make the build red in situations like we just had, where tests pass but webpacking the bundle fails.